### PR TITLE
feat: add gh action to catch up the latest official version

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -1,0 +1,139 @@
+name: Catch up the latest version
+
+on:
+  schedule:
+    - cron: '0 0 * * 0' # Runs weekly on Sunday at midnight UTC
+  workflow_dispatch:
+
+jobs:
+  update-cli:
+    runs-on: ubuntu-latest
+
+    env:
+      PR_NAME_PREFIX: "Update Salesforce CLI to"
+
+    steps:
+    - name: Checkout the repository
+      uses: actions/checkout@v4
+
+    - name: Set up Nix
+      uses: cachix/install-nix-action@v27
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+
+    - name: Install prefetch-yarn-deps
+      run: nix-env -i prefetch-yarn-deps -f '<nixpkgs>'
+
+    - name: Get the latest version from the Salesforce CLI repo
+      id: get_version
+      run: |
+        latest_version=$(curl -sS --fail https://api.github.com/repos/salesforcecli/cli/releases/latest | jq -r .tag_name)
+
+        if [ -z "$latest_version" ]; then
+          echo "Failed to fetch latest version from salesforcecli repo"
+          exit 1
+        fi
+
+        echo "version=$latest_version" >> $GITHUB_ENV
+
+    - name: Get current version
+      run: |
+        current_version=$(grep 'version = ' flake.nix | sed -E 's/.*version = "([^"]+)".*/\1/')
+
+        if [ -z "$current_version" ]; then
+            echo "Failed to extract current version from flake.nix"
+            exit 1
+        fi
+
+        echo "Current version: $current_version"
+        echo "Latest version: ${{ env.version }}"
+
+        if [ "$current_version" = "${{ env.version }}" ]; then
+          echo "The latest version is the same as the current version ($current_version). No update needed."
+          echo "update_needed=false" >> $GITHUB_ENV
+        else
+          echo "update_needed=true" >> $GITHUB_ENV
+        fi
+
+    - name: Fetch new hashes
+      if: env.update_needed == 'true'
+      run: |
+        repo_code=$(nix-prefetch-url --unpack https://github.com/salesforcecli/cli/archive/refs/tags/$version.tar.gz)
+        echo "Repo code: $repo_code"
+        repo_hash=$(nix hash to-base64 --type sha256 $repo_code)
+
+        if [ -z "$repo_hash" ]; then
+          echo "Repo hash caculation got empty value."
+          exit 1
+        fi
+        echo "Repo hash: $repo_hash"
+
+        temp_dir=$(mktemp -d)
+        curl -sS -o "$temp_dir/yarn.lock" "https://raw.githubusercontent.com/salesforcecli/cli/$version/yarn.lock"
+
+        yarn_code=$(prefetch-yarn-deps "$temp_dir/yarn.lock")
+        echo "Yarn code: $yarn_code"
+        yarn_hash=$(nix hash to-base64 --type sha256 $yarn_code)
+
+        if [ -z "$yarn_hash" ]; then
+          echo "Yarn hash caculation got empty value."
+          exit 1
+        fi
+        echo "Yarn hash: $yarn_hash"
+
+        sed -i "s|version = \".*\";|version = \"$version\";|g" flake.nix
+
+        # Because we have two `hash = ` lines to update, we simplify with preassuming
+        # 1. Assume the first hash is for the repo hash
+        sed -i "0,/hash = \"sha256-[^\"]*\"/s|hash = \"sha256-[^\"]*\"|hash = \"sha256-$repo_hash\"|" flake.nix
+
+        # 2. Assume the second hash is for the yarn.lock hash
+        sed -i "0,/hash = \"sha256-[^\"]*\"/!s|hash = \"sha256-[^\"]*\"|hash = \"sha256-$yarn_hash\"|" flake.nix
+
+        if ! grep -q "version = \"$version\"" flake.nix || ! grep -q "hash = \"sha256-$repo_hash\"" flake.nix || ! grep -q "hash = \"sha256-$yarn_hash\"" flake.nix; then
+          echo "Failed to update flake.nix"
+          exit 1
+        fi
+
+    - name: Test result by installing
+      if: env.update_needed == 'true'
+      run: |
+        nix build
+        nix shell --command sh -c "echo 'Installing the new version successfully.'"
+
+    - name: Push to Cachix
+      if: env.update_needed == 'true'
+      uses: cachix/cachix-action@v14
+      with:
+        name: sfdx-nix
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+    - name: Check for existing PRs, close them, and delete branches
+      if: env.update_needed == 'true'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        existing_prs=$(gh pr list --state open --json number,title,headRefName --jq ".[] | select(.title | startswith(\"$PR_NAME_PREFIX\")) | {number: .number, branch: .headRefName}")
+        if [ ! -z "$existing_prs" ]; then
+          echo "Closing existing PRs and deleting branches:"
+          echo "$existing_prs" | while read -r pr; do
+            number=$(echo $pr | jq -r '.number')
+            branch=$(echo $pr | jq -r '.branch')
+            echo "Closing PR #$number and deleting branch $branch"
+            gh pr close $number --comment "Closing in favor of a new update PR."
+            gh api -X DELETE repos/{owner}/{repo}/git/refs/heads/$branch
+          done
+        fi
+
+    - name: Commit and create a PR
+      if: env.update_needed == 'true'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+        git checkout -b update-cli-$version
+        git add flake.nix
+        git commit -m "Update Salesforce CLI to $version"
+        git push origin update-cli-$version
+        gh pr create --title "$PR_NAME_PREFIX $version" --body "This PR updates the Salesforce CLI to version $version." --base main --head update-cli-$version


### PR DESCRIPTION
Hi Ryan,

This GH action should save the hassle of manually catching up on the latest official version.

In a nut-shell, what it does:

1. Run periodically (weekly in the current config)
2. Check latest official version, calculate the corresponding hashses, and update `flake.nix`
3. Test the build and hash value with Cachix
4. Create PR (and close existing old PRs and branches)

It aims to automate others and have the PR approving as the manual step.

Let me know how you think.

Br,
Xi
